### PR TITLE
fix the link between order status

### DIFF
--- a/Config/module.xml
+++ b/Config/module.xml
@@ -13,7 +13,7 @@
         <language>en_US</language>
         <language>fr_FR</language>
     </languages>
-    <version>1.3.7</version>
+    <version>1.3.8</version>
     <authors>
         <author>
             <name>Etienne Perriere</name>

--- a/templates/backOffice/default/dpdclassic-order-edit.html
+++ b/templates/backOffice/default/dpdclassic-order-edit.html
@@ -1,4 +1,4 @@
-{loop type="order" name="order.tracking" id=$order_id}
+{loop type="order" name="order.tracking" id=$order_id exclude_status_code="not_paid,sent,canceled,refunded"}
     {loop name="tracking" type="dpdclassic.urltracking" ref=$REF}
         <br/>
         <div class="panel panel-default">


### PR DESCRIPTION
Fix the link between order status and only grant paid and processing to access DpdClassic module. 